### PR TITLE
Fix Dependabot alerts on Rack

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 gem 'nokogiri'
-gem 'rack', '~> 2.0.1'
+gem 'rack', '~> 2.2.4'
 gem 'rspec'
 gem 'jekyll'
 gem "webrick", "~> 1.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.1)
+      public_suffix (>= 2.0.2, < 6.0)
     colorator (1.1.0)
     concurrent-ruby (1.1.10)
     diff-lcs (1.5.0)
@@ -43,14 +43,14 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    nokogiri (1.13.8-x86_64-darwin)
+    nokogiri (1.13.8-arm64-darwin)
       racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (4.0.7)
+    public_suffix (5.0.0)
     racc (1.6.0)
-    rack (2.0.9.1)
-    rb-fsevent (0.11.1)
+    rack (2.2.4)
+    rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.5)
@@ -77,14 +77,14 @@ GEM
     webrick (1.7.0)
 
 PLATFORMS
-  x86_64-darwin-20
+  universal-darwin-21
 
 DEPENDENCIES
   jekyll
   nokogiri
-  rack (~> 2.0.1)
+  rack (~> 2.2.4)
   rspec
   webrick (~> 1.7)
 
 BUNDLED WITH
-   2.3.19
+   2.3.21


### PR DESCRIPTION
This PR should resolve Dependabot alerts [1](https://github.com/TauferLab/tauferlab.github.io/security/dependabot/1) and [2](https://github.com/TauferLab/tauferlab.github.io/security/dependabot/2).

There are two changes made in this PR:
1. The version of [rack](https://github.com/rack/rack) is bumped from 2.0.9.1 to 2.2.4 (the oldest version of rack that resolves both issues, according to Dependabot)
2. Modifies `Gemfile.lock` to account for the version bump

Note that the modifications to `Gemfile.lock` were made by running `bundle install` on a local copy of the repo. This command was run on a M1 MacBook, so there may possibly be some additional tweaks that have to be made to get the website to work on whatever service it's hosted on.