### PR TITLE
chore: change link from SOMOSPIE to SENSORY

### DIFF
--- a/research.html
+++ b/research.html
@@ -197,7 +197,7 @@ http://themeforest.net/user/owwwlab/
                       for the training of neural networks, while assuring explainable, reproducible and nearly-optimal
                       neural networks. </dd>
                     <dt>Web Page:</dt>
-                    <dd><a href="https://analytics4neuralnetworks.ai/"> A4NN</a></dd>
+                    <dd><a href="https://analytics4neuralnetworks.ai/" target="_blank"> A4NN</a></dd>
                   </div>
                 </div>
               </div>
@@ -230,7 +230,7 @@ http://themeforest.net/user/owwwlab/
                       and engage an open network of universities, including minority-serving institutions in a federated
                       data fabric configurable for individual and shared scientific use.</dd>
                     <dt>Web Page:</dt>
-                    <dd><a href="http://nsdf.sci.utah.edu/"> NSDF</a></dd>
+                    <dd><a href="http://nsdf.sci.utah.edu/" target="_blank"> NSDF</a></dd>
                   </div>
                 </div>
               </div>
@@ -269,7 +269,7 @@ http://themeforest.net/user/owwwlab/
                       global satellite measurements) and releasing this knowledge to applications in environmental
                       sciences.</dd>
                     <dt>Web Page:</dt>
-                    <dd><a href="https://globalcomputing.group/somospie/"> SOMOSPIE</a></dd>
+                    <dd><a href="https://globalcomputing.group/sensory/" target="_blank"> SENSORY</a></dd>
                   </div>
                 </div>
               </div>
@@ -298,7 +298,7 @@ http://themeforest.net/user/owwwlab/
                       modular framework for automatic measurement, analysis, and visualization of non-determinism and
                       root causes of non-determinism in MPI applications.</dd>
                     <dt>Web Page:</dt>
-                    <dd><a href="https://globalcomputing.group/anacin-x/"> Anacin-x </a></dd>
+                    <dd><a href="https://globalcomputing.group/anacin-x/" target="_blank"> Anacin-x </a></dd>
                   </div>
                 </div>
               </div>
@@ -328,7 +328,7 @@ http://themeforest.net/user/owwwlab/
                       learning and data analytics approaches, workflow management methods, and high performancecomputing
                       techniques to analyze molecular dynamics data as it is generated.</dd>
                     <dt>Web Page:</dt>
-                    <dd><a href="https://analytics4md.org/"> Analytics4MD </a></dd>
+                    <dd><a href="https://analytics4md.org/" target="_blank"> Analytics4MD </a></dd>
                   </div>
                 </div>
               </div>
@@ -381,7 +381,7 @@ http://themeforest.net/user/owwwlab/
                       ecoinformatics, a branch of informatics that analyzes ecological and environmental science
                       variables suchas information on landscapes, soils, climate, organisms, and ecosystems.</dd>
                     <dt>Web Page:</dt>
-                    <dd><a href="https://globalcomputing.group/somospie/">SOMOSPIE</a></dd>
+                    <dd><a href="https://globalcomputing.group/somospie/" target="_blank">SOMOSPIE</a></dd>
                   </div>
                 </div>
               </div>
@@ -409,7 +409,7 @@ http://themeforest.net/user/owwwlab/
                       mini-workshops called virtual world cafes to define, design, implement, and use a set of solutions
                       for robust science.</dd>
                     <dt>Web Page:</dt>
-                    <dd><a href="https://robustscience.org/#/"> RobustScience </a></dd>
+                    <dd><a href="https://robustscience.org/#/" target="_blank"> RobustScience </a></dd>
                     <!--<dd><a href="http://analytics4md.org/"> Analytics4MD </a></dd>-->
                   </div>
                 </div>


### PR DESCRIPTION
Changes the link from `somospie` to the new `sensory` in the research page.

Other:
- It adds `target="_blank"` to links in research so that it opens in a new window.